### PR TITLE
Fix certification tests

### DIFF
--- a/Certification/FilledBeforeCancelAcceptedAlgorithm.cs
+++ b/Certification/FilledBeforeCancelAcceptedAlgorithm.cs
@@ -79,7 +79,7 @@ namespace QuantConnect.Atreyu.Certification
                 new ExecutionEvent {Status = OrderStatus.CancelPending},
                 new ExecutionEvent {Status = OrderStatus.PartiallyFilled, FillQuantity = 25},
                 new ExecutionEvent {Status = OrderStatus.CancelPending},
-                new ExecutionEvent {Status = OrderStatus.Filled, FillQuantity = 50},
+                new ExecutionEvent {Status = OrderStatus.CancelPending, FillQuantity = 50},
                 new ExecutionEvent {Status = OrderStatus.Filled}
             });
         }

--- a/Certification/FilledOrderWhilePendingCancelAlgorithm.cs
+++ b/Certification/FilledOrderWhilePendingCancelAlgorithm.cs
@@ -79,7 +79,7 @@ namespace QuantConnect.Atreyu.Certification
             {
                 new ExecutionEvent {Status = OrderStatus.CancelPending },
                 new ExecutionEvent {Status = OrderStatus.CancelPending },
-                new ExecutionEvent {Status = OrderStatus.Filled, FillQuantity = 100},
+                new ExecutionEvent {Status = OrderStatus.CancelPending, FillQuantity = 100},
                 new ExecutionEvent {Status = OrderStatus.Filled}
             });
         }

--- a/Certification/FilledOrderWhilePendingReplaceAlgorithm.cs
+++ b/Certification/FilledOrderWhilePendingReplaceAlgorithm.cs
@@ -41,7 +41,7 @@ namespace QuantConnect.Atreyu.Certification
         {
             get
             {
-                return new[] { "AAPL" };
+                return new[] { "C" };
             }
         }
 
@@ -80,7 +80,7 @@ namespace QuantConnect.Atreyu.Certification
         {
             Executions[orderEvent.Symbol.Value].Executions = new Queue<ExecutionEvent>(new[]
             {
-                new ExecutionEvent {Status = OrderStatus.Filled, FillQuantity = 100},
+                new ExecutionEvent {Status = OrderStatus.UpdateSubmitted, FillQuantity = 100},
                 new ExecutionEvent {Status = OrderStatus.Filled}
             });
         }

--- a/Certification/PartFilledOrderReplaceExceedsCumQtyNoPendingAlgorithm.cs
+++ b/Certification/PartFilledOrderReplaceExceedsCumQtyNoPendingAlgorithm.cs
@@ -83,7 +83,8 @@ namespace QuantConnect.Atreyu.Certification
                 new ExecutionEvent {Status = OrderStatus.PartiallyFilled, FillQuantity = 20},
                 new ExecutionEvent {Status = OrderStatus.PartiallyFilled, FillQuantity = 20},
                 new ExecutionEvent {Status = OrderStatus.PartiallyFilled},
-                new ExecutionEvent {Status = OrderStatus.Filled, FillQuantity = 60}
+                new ExecutionEvent {Status = OrderStatus.PartiallyFilled, FillQuantity = 20},
+                new ExecutionEvent {Status = OrderStatus.Filled, FillQuantity = 40}
             });
         }
     }

--- a/Certification/ReplacedPartiallyFilledOrderAlgorithm.cs
+++ b/Certification/ReplacedPartiallyFilledOrderAlgorithm.cs
@@ -40,7 +40,7 @@ namespace QuantConnect.Atreyu.Certification
         {
             get
             {
-                return new[] { "IBM" };
+                return new[] { "FB" };
             }
         }
         private bool _replacePending = false;


### PR DESCRIPTION
- improve certification test fail report
- fix  certification tests according to new Certification Simulator [v2.2.6]([Atreyu-CertificationSimulatorTests v 2.2.6.pdf](https://github.com/QuantConnect/Lean.Brokerages.Atreyu/files/6549538/Atreyu-CertificationSimulatorTests.v.2.2.6.pdf))

updates
- D5, typo fixed in row 5
- D10b, rows' 6 & 7 quantities fixed
- E2, OrdStatus changed to “Pending Cancel”
- E2a, OrdStatus changed to “Pending Replace”